### PR TITLE
A more restrictive regex

### DIFF
--- a/lib/gigabot/commands/streams.rb
+++ b/lib/gigabot/commands/streams.rb
@@ -57,7 +57,7 @@ module Gigabot
       end
 
       def listen(m)
-        stream_url = m.message.scan(/www.twitch\.tv\/([A-z_0-9]+)/)
+        stream_url = m.message.scan(/www.twitch\.tv\/([A-z_0-9]+)\/?$/)
         if stream_url.empty?
           return
         end


### PR DESCRIPTION
This regex should correctly block out VoD URLs, while still correctly recognizing stream/channel URLs.
